### PR TITLE
Add Private Reservations

### DIFF
--- a/config/maps/1830.json
+++ b/config/maps/1830.json
@@ -44,12 +44,12 @@
       "shape": "square"
     }
   },
-  "privateHexes": {
-    "Champlain & St. Lawrence": ["b20"],
-    "Mohawk & Hudson": ["d18"],
-    "Delaware & Hudson": ["f16"],
-    "Camden & Amboy": ["h18"],
-    "Baltimore & Ohio": ["i13", "i15"]
+  "privateReservations": {
+    "b20": "C&StL",
+    "d18": "M&H",
+    "f16": "D&H",
+    "h18": "C&A",
+    "i13": "B&O"
   },
   "towns": {
     "b20": 1,
@@ -214,6 +214,7 @@
     "i15": {
       "color": "yellow",
       "label": "B",
+      "privateReservation": "B&O",
       "spots": 1,
       "trackToCenter": [0, 4],
       "type": "City",

--- a/src/components/private_reservation.tsx
+++ b/src/components/private_reservation.tsx
@@ -1,0 +1,28 @@
+import * as React from 'react';
+import { ReactElement } from 'react';
+
+import Tile from './tile';
+
+interface PrivateReservationProps {
+  name: string;
+}
+
+export default class PrivateReservation
+extends React.Component<PrivateReservationProps, undefined> {
+  public render(): ReactElement<PrivateReservation> {
+    return (
+      <g>
+        <circle cx={10} cy={45} r={4} />
+        <circle cx={10} cy={75} r={4} />
+        <line x1={10} y1={45} x2={10} y2={75} strokeWidth={2} stroke='black' />
+        <text
+          x={2}
+          y={(Tile.HEIGHT * 3 / 4) - 2}
+          textAnchor='start'
+          fill='black'
+          fontSize={Tile.SIDE_LENGTH / 8}
+        >{this.props.name}</text>
+      </g>
+    );
+  }
+}

--- a/src/map_builder.tsx
+++ b/src/map_builder.tsx
@@ -11,6 +11,7 @@ import MapHex, {
   HEX_BOTTOM, MapHexElement, MapHexProps
 } from './components/map_hex';
 import OffBoard from './components/off_board';
+import PrivateReservation from './components/private_reservation';
 import Tile from './components/tile';
 import TileCost from './components/tile_cost';
 import Token from './components/token';
@@ -36,6 +37,7 @@ export interface MapDefinition {
   names: any;
   offBoards: any;
   preplacedTile: any;
+  privateReservations: any;
   tileCostTypes: any;
   tileCosts: any;
   tileManifest: any;
@@ -177,6 +179,13 @@ export default class MapBuilder {
         } else if (this.mapDef.preplacedTile[hex]) {
           tile = tileBuilder.buildTile(
             new TileDefinition(this.mapDef.preplacedTile[hex])
+          );
+        }
+
+        if (this.mapDef.privateReservations[hex]) {
+          const name: string = this.mapDef.privateReservations[hex];
+          hexElements.push(
+            <PrivateReservation key='pcr' name={name} />
           );
         }
 

--- a/src/tile_builder.tsx
+++ b/src/tile_builder.tsx
@@ -53,6 +53,7 @@ export default class TileBuilder {
       factory.label,
       factory.tileNumber,
       factory.tileCost,
+      factory.privateReservation,
     ].filter(el => el)).flatten().toList();
 
     let key: string;

--- a/src/tile_definition.tsx
+++ b/src/tile_definition.tsx
@@ -27,6 +27,7 @@ export interface TileDefinitionInput {
   readonly label?: string;
   readonly labelPosition?: PointDefinition;
   readonly num: string;
+  readonly privateReservation: string;
   readonly rotations?: number;
   readonly spots?: number;
   readonly spotLocations?: number[];
@@ -64,6 +65,10 @@ export default class TileDefinition {
 
   public get num(): string {
     return this.definition.num;
+  }
+
+  public get privateReservation(): string {
+    return this.definition.privateReservation;
   }
 
   public get rotations(): number {

--- a/src/tile_factory.tsx
+++ b/src/tile_factory.tsx
@@ -7,6 +7,7 @@ import DistinctCity from './components/distinct_city';
 import DoubleOCity from './components/double_o_city';
 import DynamicValues from './components/dynamic_values';
 import Label from './components/label';
+import PrivateReservation from './components/private_reservation';
 import Tile, { TileElement } from './components/tile';
 import TileCost from './components/tile_cost';
 import TileNumber from './components/tile_number';
@@ -131,6 +132,15 @@ export default class TileFactory {
 
       return (
         <Label key='label' labelStr={this.definition.label} point={point} />
+      );
+    }
+  }
+
+  public get privateReservation(): ReactElement<PrivateReservation> {
+    if (this.definition.privateReservation) {
+      const name: string = this.definition.privateReservation;
+      return (
+        <PrivateReservation key='pcr' name={name} />
       );
     }
   }


### PR DESCRIPTION
This allows certain hexes to be marked as reserved for private
companies. This currently shows a mark of track on the left side of the
hex and can be configured in the future.