### PR TITLE
Restrict illegal tile upgrades

### DIFF
--- a/src/components/game.tsx
+++ b/src/components/game.tsx
@@ -147,22 +147,26 @@ export default class Game
         this.props.mapDef.tileManifest[tileNum].promotions || List<string>([])
       );
     } else {
-      let rule: any = this.props.mapDef.tilePromotions.find(
-        p => p.hexes && p.hexes.includes(hex.hex)
-      );
+      if (hex.props.allowTile) {
+        let rule: any = this.props.mapDef.tilePromotions.find(
+          p => p.hexes && p.hexes.includes(hex.hex)
+        );
 
-      if (!rule) {
-        rule = this.props.mapDef.tilePromotions.find(p => !p.hexes);
+        if (!rule) {
+          rule = this.props.mapDef.tilePromotions.find(p => !p.hexes);
+        }
+
+        tileFilter = rule.promotions;
       }
-
-      tileFilter = rule.promotions;
     }
 
-    this.store.dispatch({
-      hex: hex.hex,
-      tileFilter,
-      type: 'SHOW_AVAILABLE_TILES',
-    });
+    if (tileFilter) {
+      this.store.dispatch({
+        hex: hex.hex,
+        tileFilter,
+        type: 'SHOW_AVAILABLE_TILES',
+      });
+    }
   }
 
   private placeTile = (tile: ReactElement<Tile>): void => {

--- a/src/components/map_hex.tsx
+++ b/src/components/map_hex.tsx
@@ -21,6 +21,7 @@ const HEX_POINTS: List<string> = List([
 ]);
 
 export interface MapHexProps {
+  readonly allowTile?: boolean;
   readonly column: number;
   readonly elements?: List<MapHexElement>;
   readonly fill?: string;
@@ -36,10 +37,11 @@ export interface MapHexElement {
 export default class MapHex
   extends React.Component<MapHexProps, undefined> {
 
-  public static defaultProps: MapHexProps = {
+  public static defaultProps: Partial<MapHexProps> = {
+    allowTile: true,
     elements: List([]),
     fill: '#efe',
-  } as MapHexProps;
+  };
 
   get row(): string {
     return this.props.row;

--- a/src/map_builder.tsx
+++ b/src/map_builder.tsx
@@ -1,4 +1,5 @@
 import { List, Map } from 'immutable';
+import * as _ from 'lodash';
 import * as React from 'react';
 import { ReactElement } from 'react';
 
@@ -72,6 +73,7 @@ export default class MapBuilder {
 
       for (const column of columns) {
         let fill: string;
+        let allowTile: boolean = true;
         const hexElements: MapHexElement[] = [];
         const hex: string = row + column;
 
@@ -181,6 +183,7 @@ export default class MapBuilder {
 
         if (this.mapDef.offBoards[hex]) {
           fill = this.mapDef.offBoards[hex].color || 'red';
+          allowTile = false;
           const exits: List<number> = List<number>(
             this.mapDef.offBoards[hex].exits as string[]
           );
@@ -237,6 +240,9 @@ export default class MapBuilder {
             parseInt(tileStr[1], 10)
           );
         } else if (this.mapDef.preplacedTile[hex]) {
+          allowTile = _.flatMap(
+            this.mapDef.tilePromotions, set => set.hexes
+          ).includes(hex);
           tile = tileBuilder.buildTile(
             new TileDefinition(this.mapDef.preplacedTile[hex])
           );
@@ -257,6 +263,7 @@ export default class MapBuilder {
           column,
           fill,
           tile,
+          allowTile,
           elements: List(hexElements)
         });
       }
@@ -336,6 +343,7 @@ export default class MapBuilder {
         fill={data.fill}
         tile={data.tile}
         elements={List(data.elements)}
+        allowTile={data.allowTile}
         onHexClick={this.game.onHexClick}
       />
     ));


### PR DESCRIPTION
This restricts tile upgrades on hexes like red off boards or pre-placed
tiles without a defined upgrade path.  Previously this would allow
standard yellow tiles on these hexes.

Fixes #12.