### PR TITLE
Typescript 2.5.x upgrade

### DIFF
--- a/src/map_builder.tsx
+++ b/src/map_builder.tsx
@@ -1,5 +1,4 @@
 import { List, Map } from 'immutable';
-import * as _ from 'lodash';
 import * as React from 'react';
 import { ReactElement } from 'react';
 
@@ -176,8 +175,9 @@ class MapBuilder {
 
         if (this.mapDef.mediumCities && this.mapDef.mediumCities[hex]) {
           if (this.mapDef.mediumCities[hex] === 1) {
+            const points: List<Point> = List([this.hexagon.center]);
             hexElements.push(
-              <MediumCity points={List([this.hexagon.center])} key='town' />
+              <MediumCity points={points} key='town' />
             );
           } else {
             const points: List<Point> = List([
@@ -264,10 +264,13 @@ class MapBuilder {
             );
           }
         } else if (this.mapDef.preplacedTile[hex]) {
-          allowTile = _.includes(
-            _.flatMap(this.mapDef.tilePromotions, set => set.hexes),
-            hex
-          );
+          if (this.mapDef.tilePromotions) {
+            const promotions: List<TilePromotionTuple> = List(
+              this.mapDef.tilePromotions
+            );
+            allowTile = promotions.flatMap(set => set.hexes!).includes(hex);
+          }
+
           tile = tileBuilder.buildTile(
             new TileDefinition(
               this.mapDef,

--- a/yarn.lock
+++ b/yarn.lock
@@ -55,8 +55,8 @@
   resolved "https://registry.yarnpkg.com/@types/jest/-/jest-20.0.6.tgz#7e0ba76ddfacb42ee9bb0d8833e5208cf0680431"
 
 "@types/lodash@^4.14.72":
-  version "4.14.72"
-  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.72.tgz#f090cf6eb1fee1647a0efa1ebe18b0b78ed551c6"
+  version "4.14.77"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.77.tgz#0bc699413e84d6ed5d927ca30ea0f0a890b42d75"
 
 "@types/mime@*":
   version "0.0.29"
@@ -5780,8 +5780,8 @@ type-is@~1.6.15:
     mime-types "~2.1.15"
 
 typescript@^2.4.2:
-  version "2.4.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.4.2.tgz#f8395f85d459276067c988aa41837a8f82870844"
+  version "2.5.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.5.3.tgz#df3dcdc38f3beb800d4bc322646b04a3f6ca7f0d"
 
 ua-parser-js@^0.7.9:
   version "0.7.12"


### PR DESCRIPTION
This removes a use of underscore which generated a type error upon the
upgrade.