### PR TITLE
Fix single hex starting company

### DIFF
--- a/src/map_builder.tsx
+++ b/src/map_builder.tsx
@@ -127,7 +127,7 @@ class MapBuilder {
             );
           }
           if (this.mapDef.cities[hex] === 1) {
-            hexElements.push(React.createElement(CityCircle, ccProps));
+            hexElements.push(React.createElement(CityCircle, ccProps, token));
           } else {
             hexElements.push(
               React.createElement(


### PR DESCRIPTION
The starting company hex was only showing up in double city hexes on the
map.